### PR TITLE
Compare square.y with screen_height, not width

### DIFF
--- a/mitt-spel/examples/audio.rs
+++ b/mitt-spel/examples/audio.rs
@@ -309,7 +309,7 @@ async fn main() {
                 enemy_small_sprite.update();
 
                 // Remove shapes outside of screen
-                squares.retain(|square| square.y < screen_width() + square.size);
+                squares.retain(|square| square.y < screen_height() + square.size);
                 bullets.retain(|bullet| bullet.y > 0.0 - bullet.size / 2.0);
 
                 // Remove collided shapes

--- a/mitt-spel/examples/collision.rs
+++ b/mitt-spel/examples/collision.rs
@@ -80,7 +80,7 @@ async fn main() {
             }
 
             // Remove squares below bottom of screen
-            squares.retain(|square| square.y < screen_width() + square.size);
+            squares.retain(|square| square.y < screen_height() + square.size);
         }
 
         // Check for collisions

--- a/mitt-spel/examples/coroutines-and-storage.rs
+++ b/mitt-spel/examples/coroutines-and-storage.rs
@@ -403,7 +403,7 @@ async fn main() -> Result<(), macroquad::Error> {
                 enemy_small_sprite.update();
 
                 // Remove shapes outside of screen
-                squares.retain(|square| square.y < screen_width() + square.size);
+                squares.retain(|square| square.y < screen_height() + square.size);
                 bullets.retain(|bullet| bullet.y > 0.0 - bullet.size / 2.0);
 
                 // Remove collided shapes

--- a/mitt-spel/examples/falling-squares.rs
+++ b/mitt-spel/examples/falling-squares.rs
@@ -70,7 +70,7 @@ async fn main() {
 
         // Remove squares below bottom of screen
         // ANCHOR: removesquares
-        squares.retain(|square| square.y < screen_width() + square.size);
+        squares.retain(|square| square.y < screen_height() + square.size);
         // ANCHOR_END: removesquares
 
         // Draw everything

--- a/mitt-spel/examples/game-state.rs
+++ b/mitt-spel/examples/game-state.rs
@@ -138,7 +138,7 @@ async fn main() {
                 }
 
                 // Remove shapes outside of screen
-                squares.retain(|square| square.y < screen_width() + square.size);
+                squares.retain(|square| square.y < screen_height() + square.size);
                 bullets.retain(|bullet| bullet.y > 0.0 - bullet.size / 2.0);
 
                 // Remove collided shapes

--- a/mitt-spel/examples/graphics-enemies.rs
+++ b/mitt-spel/examples/graphics-enemies.rs
@@ -295,7 +295,7 @@ async fn main() {
                 // ANCHOR_END: updatesprites
 
                 // Remove shapes outside of screen
-                squares.retain(|square| square.y < screen_width() + square.size);
+                squares.retain(|square| square.y < screen_height() + square.size);
                 bullets.retain(|bullet| bullet.y > 0.0 - bullet.size / 2.0);
 
                 // Remove collided shapes

--- a/mitt-spel/examples/graphics-explosion.rs
+++ b/mitt-spel/examples/graphics-explosion.rs
@@ -278,7 +278,7 @@ async fn main() {
                 bullet_sprite.update();
 
                 // Remove shapes outside of screen
-                squares.retain(|square| square.y < screen_width() + square.size);
+                squares.retain(|square| square.y < screen_height() + square.size);
                 bullets.retain(|bullet| bullet.y > 0.0 - bullet.size / 2.0);
 
                 // Remove collided shapes

--- a/mitt-spel/examples/graphics-spaceship.rs
+++ b/mitt-spel/examples/graphics-spaceship.rs
@@ -290,7 +290,7 @@ async fn main() {
                 // ANCHOR_END: updatesprites
 
                 // Remove shapes outside of screen
-                squares.retain(|square| square.y < screen_width() + square.size);
+                squares.retain(|square| square.y < screen_height() + square.size);
                 bullets.retain(|bullet| bullet.y > 0.0 - bullet.size / 2.0);
 
                 // Remove collided shapes

--- a/mitt-spel/examples/menu-ui.rs
+++ b/mitt-spel/examples/menu-ui.rs
@@ -359,7 +359,7 @@ async fn main() {
                 enemy_small_sprite.update();
 
                 // Remove shapes outside of screen
-                squares.retain(|square| square.y < screen_width() + square.size);
+                squares.retain(|square| square.y < screen_height() + square.size);
                 bullets.retain(|bullet| bullet.y > 0.0 - bullet.size / 2.0);
 
                 // Remove collided shapes

--- a/mitt-spel/examples/particle-explosions.rs
+++ b/mitt-spel/examples/particle-explosions.rs
@@ -218,7 +218,7 @@ async fn main() {
                 }
 
                 // Remove shapes outside of screen
-                squares.retain(|square| square.y < screen_width() + square.size);
+                squares.retain(|square| square.y < screen_height() + square.size);
                 bullets.retain(|bullet| bullet.y > 0.0 - bullet.size / 2.0);
 
                 // Remove collided shapes

--- a/mitt-spel/examples/points.rs
+++ b/mitt-spel/examples/points.rs
@@ -102,7 +102,7 @@ async fn main() {
             }
 
             // Remove shapes outside of screen
-            squares.retain(|square| square.y < screen_width() + square.size);
+            squares.retain(|square| square.y < screen_height() + square.size);
             bullets.retain(|bullet| bullet.y > 0.0 - bullet.size / 2.0);
 
             // Remove collided shapes

--- a/mitt-spel/examples/resources-and-errors.rs
+++ b/mitt-spel/examples/resources-and-errors.rs
@@ -379,7 +379,7 @@ async fn main() -> Result<(), macroquad::Error> {
                 enemy_small_sprite.update();
 
                 // Remove shapes outside of screen
-                squares.retain(|square| square.y < screen_width() + square.size);
+                squares.retain(|square| square.y < screen_height() + square.size);
                 bullets.retain(|bullet| bullet.y > 0.0 - bullet.size / 2.0);
 
                 // Remove collided shapes

--- a/mitt-spel/examples/shooting.rs
+++ b/mitt-spel/examples/shooting.rs
@@ -102,7 +102,7 @@ async fn main() {
             // ANCHOR_END: movebullets
 
             // Remove shapes outside of screen
-            squares.retain(|square| square.y < screen_width() + square.size);
+            squares.retain(|square| square.y < screen_height() + square.size);
             // ANCHOR: removebullets
             bullets.retain(|bullet| bullet.y > 0.0 - bullet.size / 2.0);
             // ANCHOR_END: removebullets

--- a/mitt-spel/examples/spaceship-struct.rs
+++ b/mitt-spel/examples/spaceship-struct.rs
@@ -294,7 +294,7 @@ async fn main() {
                 }
 
                 // Remove shapes outside of screen
-                squares.retain(|square| square.y < screen_width() + square.size);
+                squares.retain(|square| square.y < screen_height() + square.size);
                 bullets.retain(|bullet| bullet.y > 0.0 - bullet.size / 2.0);
 
                 // Remove collided shapes

--- a/mitt-spel/examples/starfield-shader.rs
+++ b/mitt-spel/examples/starfield-shader.rs
@@ -192,7 +192,7 @@ async fn main() {
                 }
 
                 // Remove shapes outside of screen
-                squares.retain(|square| square.y < screen_width() + square.size);
+                squares.retain(|square| square.y < screen_height() + square.size);
                 bullets.retain(|bullet| bullet.y > 0.0 - bullet.size / 2.0);
 
                 // Remove collided shapes


### PR DESCRIPTION
Found a bug where we compared the y coord of the enemies with the width of the screen for retainment. Works as long as the window is square. 😄 