### PR TITLE
Add Netlfify branch build support

### DIFF
--- a/macroquad-introduction-book/Cargo.toml
+++ b/macroquad-introduction-book/Cargo.toml
@@ -1,0 +1,13 @@
+# Dummy project to cache book build dependencies with Netlify
+[package]
+name = "macroquad-introduktion"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[build-dependencies]
+mdbook = "*"
+mdbook-quiz = "*"
+mdbook-catppuccin = "*"
+mdbook-admonish = "*"

--- a/macroquad-introduction-book/rust-toolchain.toml
+++ b/macroquad-introduction-book/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "stable"

--- a/macroquad-introduction-book/src/main.rs
+++ b/macroquad-introduction-book/src/main.rs
@@ -1,0 +1,4 @@
+// Dummy project to cache book build dependencies with Netlify
+fn main() {
+    println!("Hello, world!");
+}

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,10 @@
+[build]
+  base = "macroquad-introduction-book"
+  publish = "book"
+  command = "cargo build --release && export PATH=\"$PATH:$(pwd)/target/release/build\" && mdbook build"
+
+[context.master]
+  command = "cargo build --release && export PATH=\"$PATH:$(pwd)/target/release/build\" && mdbook build"
+
+[context.branch-deploy]
+  command = "cargo build --release && export PATH=\"$PATH:$(pwd)/target/release/build\" && mdbook build"


### PR DESCRIPTION
Sort of “tricking” Netlify to build the site. Not the most elegant solution, but it worked when I tried this on my fork's `main`.

An alternative way is to do this in a GH Action and trigger Netlify to publish, but it gets a bit more involved, I think. 